### PR TITLE
Update cod-hgy7ss_cy8th8-d1e58.xml

### DIFF
--- a/cy8th8-d1e58/cod-hgy7ss_cy8th8-d1e58.xml
+++ b/cy8th8-d1e58/cod-hgy7ss_cy8th8-d1e58.xml
@@ -74,7 +74,7 @@
           formata Nunc autem quaeritur an illa pertinebunt indiffe<lb ed="#B" n="17" break="no"/>renter 
           ad quemlibet: qui vel propria autoritate vel delicentia regum 
           <lb ed="#B" n="18"/>nostrorum hispaniarum sive gubernaturum nomine regio partes illas 
-          <lb ed="#B" n="19"/>gubernantium quaesierit foderit reperit et tulerit animo sibi 
+          <lb ed="#B" n="19"/>gubernantium quaesierit foderit reperit <!--It is really a spelling mistake, but also a grammatical mistake made by the scribe. It is possible that the scribe had in mind that the word "reperio" belongs to the fourth conjugation, just like "audio", whose past form is "audivi". However, "reperio" actually belongs to the mixed conjugation and is conjugated in the past like third-conjugation verbs, just like "lego", whose past form is "legi".→ et tulerit animo sibi 
           <lb ed="#B" n="20"/>retinendi. Ita quod acquirat dominium earum rerum preciosarum 
           <lb ed="#B" n="21"/>sive thesaurorum et possit salva conscientia retinere
         </p>


### PR DESCRIPTION
I added a note: <!--It is really a spelling mistake, but also a grammatical mistake made by the scribe. It is possible that the scribe had in mind that the word "reperio" belongs to the fourth conjugation, just like "audio", whose past form is "audivi". However, "reperio" actually belongs to the mixed conjugation and is conjugated in the past like third-conjugation verbs, just like "lego", whose past form is "legi".→